### PR TITLE
Sidebar app example was broken, the data could not be sampled

### DIFF
--- a/inst/examples/sidebar_app.R
+++ b/inst/examples/sidebar_app.R
@@ -5,6 +5,14 @@ library(leaflet.extras2)
 
 data(breweries91, package = "leaflet")
 
+breweries_data <- breweries91 |>
+  st_as_sf()
+
+sample_brewery_data <- function(data, n_obs){
+  ii <- sample.int(nrow(data),n_obs,replace = TRUE)
+  data[ii,]
+}
+
 ui <- fluidPage(
   tags$head(tags$style(".btn-default {display: block;}")),
   h4("Leaflet Sidebar Plugin"),
@@ -16,45 +24,45 @@ ui <- fluidPage(
               ),
               tagList(
                 sidebar_tabs(id = "mysidebarid",
-                  list(icon("car"), icon("user"), icon("envelope")),
-                  sidebar_pane(
-                    title = "home", id = "home_id", icon = icon("home"),
-                    tagList(
-                      sliderInput("obs", "Number of observations:",
-                                  min = 1, max = 32, value = 10),
-                      sliderInput("opa", "Point Opacity:",
-                                  min = 0, max = 1, value = 0.5),
-                      sliderInput("fillopa", "Fill Opacity:",
-                                  min = 0, max = 1, value = 0.2),
-                      dateRangeInput("daterange4", "Date range:",
-                                     start = Sys.Date() - 10,
-                                     end = Sys.Date() + 10),
-                      verbatimTextOutput("tab1")
-                    )
-                  ),
-                  sidebar_pane(
-                    title = "profile", id = "profile_id", icon = icon("wrench"),
-                    tagList(
-                      textInput("caption", "Caption", "Data Summary"),
-                      selectInput("label", "Label",
-                                  choices = c("brewery", "address",
-                                              "zipcode", "village")),
-                      passwordInput("password", "Password:"),
-                      actionButton("go", "Go"),
-                      verbatimTextOutput("value")
-                    )
-                  ),
-                  sidebar_pane(
-                    title = "messages", id = "messages_id",
-                    icon = icon("person", verify_fa = FALSE),
-                    tagList(
-                      checkboxGroupInput("variable", "Variables to show:",
-                        c("Cylinders" = "cyl",
-                          "Transmission" = "am",
-                          "Gears" = "gear")),
-                      tableOutput("data")
-                    )
-                  )
+                             list(icon("car"), icon("user"), icon("envelope")),
+                             sidebar_pane(
+                               title = "home", id = "home_id", icon = icon("home"),
+                               tagList(
+                                 sliderInput("obs", "Number of observations:",
+                                             min = 1, max = 32, value = 10),
+                                 sliderInput("opa", "Point Opacity:",
+                                             min = 0, max = 1, value = 0.5),
+                                 sliderInput("fillopa", "Fill Opacity:",
+                                             min = 0, max = 1, value = 0.2),
+                                 dateRangeInput("daterange4", "Date range:",
+                                                start = Sys.Date() - 10,
+                                                end = Sys.Date() + 10),
+                                 verbatimTextOutput("tab1")
+                               )
+                             ),
+                             sidebar_pane(
+                               title = "profile", id = "profile_id", icon = icon("wrench"),
+                               tagList(
+                                 textInput("caption", "Caption", "Data Summary"),
+                                 selectInput("label", "Label",
+                                             choices = c("brewery", "address",
+                                                         "zipcode", "village")),
+                                 passwordInput("password", "Password:"),
+                                 actionButton("go", "Go"),
+                                 verbatimTextOutput("value")
+                               )
+                             ),
+                             sidebar_pane(
+                               title = "messages", id = "messages_id",
+                               icon = icon("person", verify_fa = FALSE),
+                               tagList(
+                                 checkboxGroupInput("variable", "Variables to show:",
+                                                    c("Cylinders" = "cyl",
+                                                      "Transmission" = "am",
+                                                      "Gears" = "gear")),
+                                 tableOutput("data")
+                               )
+                             )
                 ),
                 leafletOutput("map", height = "700px")
               )
@@ -70,9 +78,14 @@ server <- function(input, output, session) {
         options = list(position = "left")
       )
   })
+
   observe({
+
     req(input$obs)
-    df <- breweries91[sample.int(nrow(breweries91), input$obs), ]
+
+    df <- breweries_data |>
+      sample_brewery_data(n_obs = input$obs)
+
     bbox <- suppressWarnings(st_bbox(df))
     leafletProxy("map", session) %>%
       clearGroup("pts") %>%
@@ -92,7 +105,7 @@ server <- function(input, output, session) {
     isolate(input$password)
   })
   output$data <- renderTable(rownames = FALSE, {
-      mtcars[, c("mpg", input$variable), drop = FALSE]
+    mtcars[, c("mpg", input$variable), drop = FALSE]
   })
 
   observeEvent(input$open, {


### PR DESCRIPTION
Hi and thanks for all the new updates! I haven't looked in a while and am happy to see lots of new things to try.
I will try all the examples.

the `breweries91` dataset was now after updating packages a spatialpointsdataframe which could not be sampled with something like `data[sample.int(nrow(data),...`
I have now converted it to an `sf` dataframe.
