### PR TITLE
Fix tests to prepare for upcoming leaflet v2.2.0 release

### DIFF
--- a/tests/testthat/test-movingmarker.R
+++ b/tests/testthat/test-movingmarker.R
@@ -32,8 +32,10 @@ test_that("movingmarker", {
                     popup="Arrr")
   expect_is(m, "leaflet")
   expect_equal(m$x$calls[[1]]$method, "addMovingMarker")
-  expect_equal(m$dependencies[[1]]$name, "lfx-movingmarker")
-  expect_equal(m$dependencies[[2]]$name, "leaflet-awesomemarkers")
+  expect_contains(
+    vapply(m$dependencies, function(x) x$name, character(1)),
+    c("lfx-movingmarker", "leaflet-awesomemarkers")
+  )
 
   ## Data is Simple Feature LINESTRING
   df <- sf::st_as_sf(atlStorms2005)[1,]


### PR DESCRIPTION
Hi @trafficonese! We're preparing the next release of leaflet (v2.2.0, rstudio/leaflet#876) and noticed that our updates break a test in your package.

I've provided a fix in this PR. In essence, `leaflet()` now includes its own dependencies in the `dependencies` item of the returned htmlwidgets object, which means that it contains both our dependencies and the dependencies your extension has added. The updated test now finds the name of all dependencies in the object and ensures that `lfx-movingmarker` and `leaflet-awesomemarkers` are included. This ensures that they're included in the list of dependencies, but you may want to add an additional check to test that they're included in that order (if that's important to your extension).

Do you think you'd be able to update your package on CRAN in the next two weeks? We're planning on submitting leaflet v2.2.0 on Tuesday, August 29 at the latest and are hoping we can have all reverse dependencies issues worked out by then. Thanks!