### PR TITLE
fix: Export scale=3 as a sharper PNG of the current view instead of zooming in and shrinking OSM labels.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,10 +19,10 @@
   `input$MAPID_antpath_click` / `_mouseover` / `_mouseout` instead of `shape_*`.
 * `addEasyprint()` custom export sizes no longer need extra CSS. Pass them in
   `easyprintOptions(sizeModes = ...)` as R lists, for example
-  `list(scale = 3, name = "3x current view")` or
-  `list(width = 3000, height = 1800, name = "High res")`.
+  `list(scale = 3, name = "3x current view")` (same zoom and labels,
+  more pixels) or `list(width = 3000, height = 1800, name = "High res")`.
   `CurrentSize` still exports at the widget size (often low-res in Quarto/HTML).
-  Custom sizes keep the current map view by default (`keepView = TRUE` in the
+  Custom width/height sizes keep the current map view by default (`keepView = TRUE` in the
   size-mode list). Set `keepView = FALSE` to keep the zoom level and export a
   larger area. See `inst/examples/easyprint.R`.
 

--- a/R/easyprint.R
+++ b/R/easyprint.R
@@ -2,7 +2,7 @@ easyprintDependency <- function() {
   list(
     htmltools::htmlDependency(
       "lfx-easyprint",
-      version = "1.0.0",
+      version = "1.0.1",
       src = system.file("htmlwidgets/lfx-easyprint",
         package = "leaflet.extras2"
       ),
@@ -124,12 +124,13 @@ removeEasyprint <- function(map) {
 #'   optionally \code{name} / \code{className}):
 #'   \code{list("CurrentSize", list(width = 3000, height = 1800, name = "High res"))}.
 #'   \code{CurrentSize} exports at the current map widget size (often low
-#'   resolution in Quarto/HTML documents). A custom size resizes the map before
-#'   export. By default \code{keepView = TRUE}: the current view is kept (zoom
-#'   in, same aspect ratio; the PNG may be smaller than \code{width}/\code{height}
-#'   on one side). Use \code{keepView = FALSE} to keep the zoom level and show a
-#'   larger area, like A4. \code{list(scale = 3, name = "3x current view")}
-#'   multiplies the current widget size and keeps the exact view.
+#'   resolution in Quarto/HTML documents).
+#'   \code{list(scale = 3)} captures the current view at 3x pixel resolution
+#'   without changing zoom or tile labels (best for presentations).
+#'   A custom \code{width}/\code{height} resizes the map before export.
+#'   By default \code{keepView = TRUE}: the same bounds are kept by zooming
+#'   in, so OSM/tile labels get smaller. Use \code{keepView = FALSE} to keep
+#'   the zoom level and show a larger area, like A4.
 #'   A custom \code{className} and CSS background-image are optional;
 #'   see \code{./inst/examples/easyprint.R} and
 #'   \code{./inst/examples/easyprint_app.R}.

--- a/inst/examples/easyprint.R
+++ b/inst/examples/easyprint.R
@@ -2,8 +2,8 @@ library(leaflet)
 library(leaflet.extras2)
 
 ## Static map (Quarto/HTML): CurrentSize exports at widget size.
-## scale = 3 exports the current view at 3x pixel size.
-## width/height keep the current view by default (keepView = TRUE).
+## scale = 3 = same view/zoom/labels, 3x pixels (for presentations).
+## width/height + keepView zooms in (OSM labels get smaller).
 leaflet() %>%
   fitBounds(-91, 47, -87, 50) %>%
   addProviderTiles("Esri.WorldTopoMap", group = "Topographic") %>%

--- a/inst/examples/easyprint_app.R
+++ b/inst/examples/easyprint_app.R
@@ -2,6 +2,7 @@ library(shiny)
 library(leaflet)
 library(leaflet.extras2)
 
+
 ui <- fluidPage(
   tags$head(tags$style(".easyPrintHolder .customCssClass {
                             background-image: url(data:image/svg+xml;utf8;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pgo8IS0tIEdlbmVyYXRvcjogQWRvYmUgSWxsdXN0cmF0b3IgMTguMS4xLCBTVkcgRXhwb3J0IFBsdWctSW4gLiBTVkcgVmVyc2lvbjogNi4wMCBCdWlsZCAwKSAgLS0+CjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0iQ2FwYV8xIiB4PSIwcHgiIHk9IjBweCIgdmlld0JveD0iMCAwIDQ0NC44MzMgNDQ0LjgzMyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNDQ0LjgzMyA0NDQuODMzOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgd2lkdGg9IjUxMnB4IiBoZWlnaHQ9IjUxMnB4Ij4KPGc+Cgk8Zz4KCQk8cGF0aCBkPSJNNTUuMjUsNDQ0LjgzM2gzMzQuMzMzYzkuMzUsMCwxNy03LjY1LDE3LTE3VjEzOS4xMTdjMC00LjgxNy0xLjk4My05LjM1LTUuMzgzLTEyLjQ2N0wyNjkuNzMzLDQuNTMzICAgIEMyNjYuNjE3LDEuNywyNjIuMzY3LDAsMjU4LjExNywwSDU1LjI1Yy05LjM1LDAtMTcsNy42NS0xNywxN3Y0MTAuODMzQzM4LjI1LDQzNy4xODMsNDUuOSw0NDQuODMzLDU1LjI1LDQ0NC44MzN6ICAgICBNMzcyLjU4MywxNDYuNDgzdjAuODVIMjU2LjQxN3YtMTA4LjhMMzcyLjU4MywxNDYuNDgzeiBNNzIuMjUsMzRoMTUwLjE2N3YxMzAuMzMzYzAsOS4zNSw3LjY1LDE3LDE3LDE3aDEzMy4xNjd2MjI5LjVINzIuMjVWMzR6ICAgICIgZmlsbD0iIzAwMDAwMCIvPgoJPC9nPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+CjxnPgo8L2c+Cjwvc3ZnPgo=);
@@ -15,6 +16,7 @@ ui <- fluidPage(
   leafletOutput("map", height = 700, width = "100%"),
   selectInput("scene", "Select Scene",
               choices = c("CurrentSize" = "CurrentSize",
+                          "3x current view" = "custom-scale-3",
                           "A4Landscape" = "A4Landscape",
                           "A4Portrait" = "A4Portrait",
                           "Custom Landscape" = "customCssClass",
@@ -25,13 +27,25 @@ ui <- fluidPage(
   actionButton("cle", "clearControls")
 )
 
+brewery_xy <- function() {
+  brews <- leaflet::breweries91
+  if (inherits(brews, "sf")) {
+    xy <- sf::st_coordinates(brews)
+    data.frame(lng = xy[, 1], lat = xy[, 2], brewery = brews$brewery)
+  } else {
+    xy <- sp::coordinates(brews)
+    data.frame(lng = xy[, 1], lat = xy[, 2], brewery = brews$brewery)
+  }
+}
+
 server <- function(input, output, session) {
   output$map <- renderLeaflet({
+    pts <- brewery_xy()
     leaflet()  %>%
       addTiles(group = "basemap") %>%
-      addCircleMarkers(data = leaflet::breweries91,
+      addCircleMarkers(data = pts, lng = ~lng, lat = ~lat,
                        group = "markers", popup = ~brewery, label = ~brewery) %>%
-      addPopups(data = leaflet::breweries91[1:5, ],
+      addPopups(data = pts[1:5, ], lng = ~lng, lat = ~lat,
                 group = "popups", popup = ~brewery) %>%
       addEasyprint(options = easyprintOptions(
         title = "Give me that map",
@@ -49,6 +63,7 @@ server <- function(input, output, session) {
         ),
         # sizeModes = c("A4Portrait","A4Landscape"),
         sizeModes = list("CurrentSize" = "CurrentSize",
+                         list(scale = 3, name = "3x current view"),
                          "A4Landscape" = "A4Landscape",
                          "A4Portrait" = "A4Portrait",
                          "Custom Landscape" = list(

--- a/inst/htmlwidgets/lfx-easyprint/lfx-easyprint_full.js
+++ b/inst/htmlwidgets/lfx-easyprint/lfx-easyprint_full.js
@@ -127,6 +127,10 @@ L.Control.EasyPrint = L.Control.extend({
     if (sizeMode === 'CurrentSize') {
       return this._printOpertion(sizeMode);
     }
+    var dpiMode = this._findPageSize(sizeMode);
+    if (this._isDpiScaleMode(dpiMode)) {
+      return this._printAtDpi(Number(dpiMode.scale));
+    }
     if (!this._findPageSize(sizeMode)) {
       console.error('easyPrint: could not resolve size mode', sizeMode, this.options.sizeModes);
       L.DomUtil.removeClass(this.mapContainer, 'easyprint-exporting');
@@ -166,6 +170,68 @@ L.Control.EasyPrint = L.Control.extend({
       }
     }
     return classes.filter(function (c) { return c && c !== 'CustomSize'; })[0] || '';
+  },
+
+  _isDpiScaleMode: function (pageSize) {
+    return !!(pageSize && pageSize.scale != null &&
+      (pageSize.width == null || pageSize.height == null));
+  },
+
+  _printAtDpi: function (scale) {
+    var plugin = this;
+    if (!isFinite(scale) || scale <= 0) {
+      scale = 1;
+    }
+    var w = this.originalState.pixelWidth || this._map.getSize().x;
+    var h = this.originalState.pixelHeight || this._map.getSize().y;
+    this.orientation = w >= h ? 'landscape' : 'portrait';
+    domtoimage.toPng(this.mapContainer, {
+      width: Math.round(w * scale),
+      height: Math.round(h * scale),
+      style: {
+        transform: 'scale(' + scale + ')',
+        'transform-origin': 'top left',
+        width: w + 'px',
+        height: h + 'px'
+      }
+    })
+    .then(function (dataUrl) {
+      var blob = plugin._dataURItoBlob(dataUrl);
+      if (plugin.options.exportOnly) {
+        saveAs(blob, plugin.options.filename + '.png');
+      } else {
+        plugin._sendToBrowserPrint(dataUrl, plugin.orientation);
+      }
+      plugin._restoreAfterPrint();
+      plugin._map.fire("easyPrint-finished");
+    })
+    .catch(function (error) {
+      console.error('Print operation failed', error);
+      plugin._restoreAfterPrint();
+    });
+  },
+
+  _restoreAfterPrint: function () {
+    L.DomUtil.removeClass(this.mapContainer, 'easyprint-exporting');
+    this._toggleControls(true);
+    this._toggleClasses(this.options.hideClasses, true);
+    if (this.outerContainer) {
+      if (this.originalState.widthWasAuto) {
+        this.mapContainer.style.width = 'auto';
+      } else if (this.originalState.widthWasPercentage) {
+        this.mapContainer.style.width = this.originalState.percentageWidth;
+      } else {
+        this.mapContainer.style.width = this.originalState.mapWidthStyle;
+      }
+      this.mapContainer.style.height = this.originalState.mapHeightStyle;
+      this._removeOuterContainer(this.mapContainer, this.outerContainer, this.blankDiv);
+      if (this.originalState.maxZoom !== undefined) {
+        this._map.options.maxZoom = this.originalState.maxZoom;
+      }
+      this._map.invalidateSize();
+      this._map.setView(this.originalState.center);
+      this._map.setZoom(this.originalState.zoom);
+    }
   },
 
   _findPageSize: function (sizeMode) {
@@ -303,27 +369,7 @@ L.Control.EasyPrint = L.Control.extend({
     }
 
     function restorePlugin(plugin) {
-      L.DomUtil.removeClass(plugin.mapContainer, 'easyprint-exporting');
-      plugin._toggleControls(true);
-      plugin._toggleClasses(plugin.options.hideClasses, true);
-
-      if (plugin.outerContainer) {
-        if (plugin.originalState.widthWasAuto) {
-          plugin.mapContainer.style.width = 'auto'
-        } else if (plugin.originalState.widthWasPercentage) {
-          plugin.mapContainer.style.width = plugin.originalState.percentageWidth
-        } else {
-          plugin.mapContainer.style.width = plugin.originalState.mapWidthStyle;
-        }
-        plugin.mapContainer.style.height = plugin.originalState.mapHeightStyle;
-        plugin._removeOuterContainer(plugin.mapContainer, plugin.outerContainer, plugin.blankDiv)
-        if (plugin.originalState.maxZoom !== undefined) {
-          plugin._map.options.maxZoom = plugin.originalState.maxZoom;
-        }
-        plugin._map.invalidateSize();
-        plugin._map.setView(plugin.originalState.center);
-        plugin._map.setZoom(plugin.originalState.zoom);
-      }
+      plugin._restoreAfterPrint();
     }
     var exportWidth = parseInt(widthForExport, 10) || plugin._map.getSize().x;
     var exportHeight = parseInt(plugin.mapContainer.style.height, 10) || plugin._map.getSize().y;

--- a/man/easyprintOptions.Rd
+++ b/man/easyprintOptions.Rd
@@ -32,12 +32,13 @@ sizes can be mixed in as lists with \code{width} and \code{height} (and
 optionally \code{name} / \code{className}):
 \code{list("CurrentSize", list(width = 3000, height = 1800, name = "High res"))}.
 \code{CurrentSize} exports at the current map widget size (often low
-resolution in Quarto/HTML documents). A custom size resizes the map before
-export. By default \code{keepView = TRUE}: the current view is kept (zoom
-in, same aspect ratio; the PNG may be smaller than \code{width}/\code{height}
-on one side). Use \code{keepView = FALSE} to keep the zoom level and show a
-larger area, like A4. \code{list(scale = 3, name = "3x current view")}
-multiplies the current widget size and keeps the exact view.
+resolution in Quarto/HTML documents).
+\code{list(scale = 3)} captures the current view at 3x pixel resolution
+without changing zoom or tile labels (best for presentations).
+A custom \code{width}/\code{height} resizes the map before export.
+By default \code{keepView = TRUE}: the same bounds are kept by zooming
+in, so OSM/tile labels get smaller. Use \code{keepView = FALSE} to keep
+the zoom level and show a larger area, like A4.
 A custom \code{className} and CSS background-image are optional;
 see \code{./inst/examples/easyprint.R} and
 \code{./inst/examples/easyprint_app.R}.}

--- a/tests/testthat/test-easyprint.R
+++ b/tests/testthat/test-easyprint.R
@@ -191,5 +191,7 @@ test_that("easyprint JS keeps the current view when resizing", {
   expect_match(js, "viewScale")
   expect_match(js, "pixelWidth")
   expect_match(js, "Math\\.log\\(viewScale\\)")
+  expect_match(js, "_printAtDpi")
+  expect_match(js, "transform-origin")
   expect_match(js, "CustomSize")
 })


### PR DESCRIPTION
fixes #85 